### PR TITLE
Ensure supervisor service is started

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,3 +32,6 @@
 
 - name: configure logrotate
   copy: src=supervisord_logrotate dest=/etc/logrotate.d/supervisord
+
+- name: Start Supervisor
+  service: name=supervisor state=started


### PR DESCRIPTION
After including this role (on Ubuntu 14.04), the sysvinit service is not started (i believe the restart handler is not dispatched ?) and further roles that install a Supervisor program fail starting the supervisor service (with a `started` state):

```
TASK: [some-task | Ensure Supervisord job is present] ***********
failed: [vm-01] => {"cmd": "/usr/local/bin/supervisorctl reread", "failed": true, "rc": 2}
stdout: error: <class 'socket.error'>, [Errno 111] Connection refused: file: /usr/lib/python2.7/socket.py line: 571
```

I'm not certain if this behaviour is intentional, but in any case i added a task to start the service by default.
